### PR TITLE
Use blank filter by default

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -4,7 +4,7 @@
 #Requires -Version 7
 
 param(
-    [Parameter(Mandatory = $false)][string] $Filter = "*",
+    [Parameter(Mandatory = $false)][string] $Filter = "",
     [Parameter(Mandatory = $false)][string] $Job = ""
 )
 


### PR DESCRIPTION
macOS appears to not like the `*` for some reason.
