### PR TITLE
Use official NuGet packages

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,13 +2,9 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="dotnet9">
-      <package pattern="*" />
-    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.7.24406.8",
+    "version": "9.0.100-preview.7.24407.12",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }


### PR DESCRIPTION
- Use official NuGet packages for .NET 9 preview 7.
- Update .NET SDK.
