### PR TITLE
Update NuGet packages

### DIFF
--- a/tests/TodoApp.Tests/TodoApp.Tests.csproj
+++ b/tests/TodoApp.Tests/TodoApp.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.21" />
     <PackageReference Include="Microsoft.Playwright" Version="1.47.0" />
     <PackageReference Include="Verify.Xunit" Version="26.6.0" />
-    <PackageReference Include="xunit" Version="2.9.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Update NuGet packages to their latest versions while dependabot does not support .NET 9.
