### PR TITLE
Remove BENCHMARKS_TOKEN

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -78,7 +78,7 @@ jobs:
         name: 'ASP.NET Core OpenAPI'
         output-file-path: '${{ steps.get-repo-name.outputs.repo-name }}/data.json'
         repo: '${{ github.repository_owner }}/benchmarks'
-        repo-token: ${{ secrets.BENCHMARKS_TOKEN }}
+        repo-token: ${{ steps.get-github-token.outputs.token }}
 
     - name: Output summary
       shell: pwsh

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,6 +28,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     steps:
 
@@ -60,8 +61,17 @@ jobs:
         $repoName = ${env:GITHUB_REPOSITORY}.Split("/")[-1]
         "repo-name=${repoName}" >> ${env:GITHUB_OUTPUT}
 
+    - name: Get GitHub token
+      id: get-github-token
+      if: github.event.repository.fork == false
+      # zizmor: ignore[ref-version-mismatch] False positive
+      uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+      with:
+        profile-name: benchmarks
+
     - name: Publish results
       uses: martincostello/benchmarkdotnet-results-publisher@0f2a458a28dbd963b1bcb029efaec245b677c7b3 # v2.0.3
+      if: github.event.repository.fork == false
       with:
         branch: ${{ github.ref_name }}
         comment-on-threshold: true


### PR DESCRIPTION
Remove use of the `BENCHMARKS_TOKEN` secret and use the GitHub token broker instead.
